### PR TITLE
Update readme for Leap's collection of examples page

### DIFF
--- a/01-exploring-pegasus.ipynb
+++ b/01-exploring-pegasus.ipynb
@@ -9,7 +9,7 @@
     "    \n",
     "1. [The Pegasus Advantage](#The-Pegasus-Advantage) demonstrates and explains the performance differences between the previous and new QPU architectures.\n",
     "2. [Navigating the Topology](#Navigating-the-Topology) describes the new topology and presents Ocean tools that help you use it.\n",
-    "3. [Example Problem: RANr](#Example-Problem:-RANr) solves a hard problem on Advantage and DW-2000Q quantum computers.\n",
+    "3. [Example Problem: RANr](#Example-Problem:-RANr) solves a hard problem on Advantage and D-Wave 2000Q quantum computers.\n",
     "\n",
     "This notebook should familiarize you with the Pegasus topology and the tools to use it.\n",
     "\n",
@@ -31,7 +31,7 @@
     "\n",
     "The Advantage system is distinct from all previous generations of D-Wave's quantum computers in being the first to employ a new architecture made possible by recent advances in QPU fabrication technology. \n",
     "\n",
-    "QPUs are lattices of interconnected qubits. While some qubits connect to others via couplers, QPUs are not fully connected. Instead, qubits interconnect in a topology: Chimera for the DW-2000Q and Pegasus for the Advantage.\n",
+    "QPUs are lattices of interconnected qubits. While some qubits connect to others via couplers, QPUs are not fully connected. Instead, qubits interconnect in a topology: Chimera for the D-Wave 2000Q and Pegasus for the Advantage.\n",
     "\n",
     "QPU topology is crucial to *embedding* problems onto quantum computers, determining what problems can be addressed and affecting the quality of solutions. Pegasus topology was designed for the real-world problems of business applications."
    ]
@@ -81,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Pegasus topology enables the Advantage QPU to more than double the number of available qubits compared to the DW-2000Q, and the working graph is denser, meaning each qubit is coupled to a greater number of neighboring qubits. "
+    "The Pegasus topology enables the Advantage QPU to more than double the number of available qubits compared to the D-Wave 2000Q, and the working graph is denser, meaning each qubit is coupled to a greater number of neighboring qubits. "
    ]
   },
   {
@@ -89,7 +89,7 @@
    "metadata": {},
    "source": [
     "## More Qubits and Denser Connectivity\n",
-    "When looking at summary differences between generations of QPUs, one naturally tends to first notice the increase in number of qubits. A DW-2000Q has over 2,000 while the Advantage has over 5,000. That increase is important; this notebook shows why connectivity deserves your attention too.   \n",
+    "When looking at summary differences between generations of QPUs, one naturally tends to first notice the increase in number of qubits. A D-Wave 2000Q has over 2,000 while the Advantage has over 5,000. That increase is important; this notebook shows why connectivity deserves your attention too.   \n",
     "\n",
     "This section also introduces useful Ocean software tools that let you work and experiment with the QPU topology locally on your computer. Unless you are solving a problem, as section [Example Problem: RANr](#Example-Problem:-RANr) does, you can explore the topology without needing to access a system.\n",
     "\n",
@@ -102,7 +102,7 @@
    "source": [
     "*dwave_networkx* provides functionality to create Chimera and Pegasus lattices of varying sizes. This first code cell creates Chimera and Pegasus graphs of size CN $=$ C16 and PN $=$ P16. \n",
     "\n",
-    "The notation CN refers to a Chimera lattice consisting of an $NxN$ grid of *unit cells*. Unit cells are described in more detail below; for now it's sufficient to think of them as vertically and horizontally tiled, sparsely connected, groups of more densely connected qubits. The DW-2000Q has a C16 lattice, meaning a grid of $16x16$ unit cells. The Advantage has a P16 lattice that is explored below. \n",
+    "The notation CN refers to a Chimera lattice consisting of an $NxN$ grid of *unit cells*. Unit cells are described in more detail below; for now it's sufficient to think of them as vertically and horizontally tiled, sparsely connected, groups of more densely connected qubits. The D-Wave 2000Q has a C16 lattice, meaning a grid of $16x16$ unit cells. The Advantage has a P16 lattice that is explored below. \n",
     "\n"
    ]
   },
@@ -155,7 +155,7 @@
     "## Test Case: Embedding Random Graphs \n",
     "Advantage was developed to meet D-Wave customers' need for increased capability to embed larger and more complex problems. The resulting Pegasus topology enables the embedding of problems with shorter chains, which can result in higher quality solutions, as demonstrated in section [Example Problem: RANr](#Example-Problem:-RANr).  \n",
     "\n",
-    "To demonstrate the benefits of the Pegasus topology, the following subsections compare its performance with that of the Chimera. This is done by generating and embedding many random graphs that are representative of problems of sizes commensurate with the size of a DW-2000Q QPU.   \n",
+    "To demonstrate the benefits of the Pegasus topology, the following subsections compare its performance with that of the Chimera. This is done by generating and embedding many random graphs that are representative of problems of sizes commensurate with the size of a D-Wave 2000Q QPU.   \n",
     "\n",
     "<div class=\"alert alert-warning\" role=\"alert\" style=\"margin: 10px\">The demonstrations of this section do not submit problems to a D-Wave system for solution, and so are not associated with a cost for QPU usage time.</div>\n",
     "\n",
@@ -190,7 +190,7 @@
     "\n",
     "<img src=\"images/random_graph_100_2.png\" width=300x/>\n",
     "\n",
-    "An embedding on a DW-2000Q:\n",
+    "An embedding on a D-Wave 2000Q:\n",
     "<img src=\"images/c16_random_graph_100_2.png\" width=700x/>\n",
     "\n",
     "An embedding on an Advantage:\n",
@@ -269,7 +269,7 @@
     "## Performance on Sparse Graphs\n",
     "A graph is considered sparse to the extent that its $n$ nodes have fewer edges than a $K_n$ complete graph. For example, a graph representing a large transportation network is likely sparse because its many nodes (intersections) typically have just three or four edges (ingressing/egressing roads). \n",
     "\n",
-    "As mentioned above, the difference most often highlighted between generations of QPUs is the increase in number of qubits. Intuitively, if the maximum problem size for a QPU were simply proportional to its number of qubits, sparse graphs should be the place to see that. One might imagine a string of qubits coupled head to tail, like a pearl necklace, representing the embedded nodes of a sparse graph. Should one expect the embedding limit for sparse graphs to increase from around 2,000 nodes on a DW-2000Q to 5,000 on the Advantage?\n",
+    "As mentioned above, the difference most often highlighted between generations of QPUs is the increase in number of qubits. Intuitively, if the maximum problem size for a QPU were simply proportional to its number of qubits, sparse graphs should be the place to see that. One might imagine a string of qubits coupled head to tail, like a pearl necklace, representing the embedded nodes of a sparse graph. Should one expect the embedding limit for sparse graphs to increase from around 2,000 nodes on a D-Wave 2000Q to 5,000 on the Advantage?\n",
     "\n",
     "A graph where each node has only two edges is such a sparse problem.\n",
     "\n",
@@ -499,7 +499,7 @@
    "source": [
     "These last two subsections highlighted two points: \n",
     "\n",
-    "* A topology with denser connectivity enables you to scale up your problems (graphs) in terms of both the number of variables (nodes) and the density of the variables' interactions (edges). As noted above, a DW-2000Q has over 2,000 qubits while the Advantage has over 5,000, and that increase is important; however, you should now also recognize the significance of increasing the number of couplers from over 5,500 on a DW-2000Q to over 35,000 on the Advantage. \n",
+    "* A topology with denser connectivity enables you to scale up your problems (graphs) in terms of both the number of variables (nodes) and the density of the variables' interactions (edges). As noted above, a D-Wave 2000Q has over 2,000 qubits while the Advantage has over 5,000, and that increase is important; however, you should now also recognize the significance of increasing the number of couplers from over 5,500 on a D-Wave 2000Q to over 35,000 on the Advantage. \n",
     "* Real-time applications should take into consideration the computation time of minor-embedding heuristic algorithms. Subsection [Performance on Cliques](#Performance-on-Cliques) below shows one way of doing so. "
    ]
   },
@@ -660,7 +660,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have access to both a DW-2000Q and Advantage system, print the yields for both QPUs."
+    "If you have access to both a D-Wave 2000Q and Advantage system, print the yields for both QPUs."
    ]
   },
   {
@@ -774,7 +774,7 @@
    "metadata": {},
    "source": [
     "# Navigating the Topology\n",
-    "The previous section demonstrated the importance of QPU connectivity for embedding problems on a quantum computer. That connectivity is proportional to the number of its couplers: a DW-2000Q has up to 6,016 couplers; an Advantage has up to 40,484 couplers. \n",
+    "The previous section demonstrated the importance of QPU connectivity for embedding problems on a quantum computer. That connectivity is proportional to the number of its couplers: a D-Wave 2000Q has up to 6,016 couplers; an Advantage has up to 40,484 couplers. \n",
     "\n",
     "The previous section also mentioned the lattice structure of the Chimera QPU and its relevance to embedding for such problems as those formulated with Boolean gates.\n",
     "\n",
@@ -1237,7 +1237,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below is a [dwave-inspector](https://docs.ocean.dwavesys.com/en/stable/docs_inspector/sdk_index.html) image of this problem embedded in a DW-2000Q QPU:\n",
+    "Below is a [dwave-inspector](https://docs.ocean.dwavesys.com/en/stable/docs_inspector/sdk_index.html) image of this problem embedded in a D-Wave 2000Q QPU:\n",
     "\n",
     "<img src='images/16qubit_problem_embedding_chimera.png' width=600x>"
    ]
@@ -1600,7 +1600,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "The figure below shows a histogram for naively combining results from two particular quantum computer systems of a large number (fifty) of similar problems: RAN7 problems generated for [NetworkX](http://networkx.github.io/) `nx.random_regular_graph()` graphs of 50 nodes and 40 edges each, with chain strength of 25 for Advantage and 35 for the DW-2000Q. \n",
+    "The figure below shows a histogram for naively combining results from two particular quantum computer systems of a large number (fifty) of similar problems: RAN7 problems generated for [NetworkX](http://networkx.github.io/) `nx.random_regular_graph()` graphs of 50 nodes and 40 edges each, with chain strength of 25 for Advantage and 35 for the D-Wave 2000Q. \n",
     "\n",
     "<img src=\"images/ran7_50problems.png\" width=500x/>\n",
     "\n",

--- a/README.md
+++ b/README.md
@@ -9,6 +9,47 @@ unit (QPU) with a new architecture: the Pegasus family of topologies. This
 notebook explains the Pegasus topology and how it enables superior performance
 to previous generations of quantum computers.
 
+The notebook has the following sections:
+
+1. **The Pegasus Advantage** demonstrates and explains the performance differences
+   between the previous and new QPU architectures.
+2. **Navigating the Topology** describes the new topology and presents Ocean tools
+   that help you use it.
+3. **Example Problem: RANr** solves a hard problem on Advantage and D-Wave 2000Q
+   quantum computers.
+
+## QPU Architecture: Topologies
+
+The layout of the D-Wave QPU is critical to formulating an objective
+function in a format that a D-Wave annealing quantum computer can solve.
+Although Ocean software automates the mapping from the linear and quadratic
+coefficients of a quadratic model to qubit bias and coupling values set on the
+QPU, you should understand it if you are using QPU solvers directly because it
+has implications for the problem-graph size and solution quality.
+
+The D-Wave QPU is a lattice of interconnected qubits.
+While some qubits connect to others via couplers, the D-Wave QPU is not fully
+connected. Instead, the qubits of D-Wave annealing quantum computers interconnect
+in one of the following topologies:
+
+* Chimera for D-Wave 2000Q and earlier generations of QPUs
+* Pegasus for Advantage QPUs
+
+These topologies are described in D-Wave's
+[system documentation](https://docs.dwavesys.com/docs/latest/c_gs_4.html).
+
+![comparison](images/ran7_50problems_first5.png)
+
+## Installation
+
+You can run this example
+[in the Leap IDE](https://ide.dwavesys.io/#https://github.com/dwave-examples/pegasus-notebook).
+
+Alternatively, install requirements locally (ideally, in a virtual environment):
+
+    pip install -r requirements.txt
+
+
 ## Usage
 
 To enable notebook extensions:


### PR DESCRIPTION
Added content from docs, added an installation section, fixed a long-missed naming bug (I don't know how we never spotted this one).