### PR TITLE
Remove use of SAPI's ``num_spin_reversal_transforms`` property to meet runtime limit

### DIFF
--- a/01-exploring-pegasus.ipynb
+++ b/01-exploring-pegasus.ipynb
@@ -1556,7 +1556,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "num_reads = 5000\n",
+    "num_reads = 4000\n",
     "\n",
     "num_nodes = 50\n",
     "num_edges = 40\n",
@@ -1567,7 +1567,6 @@
     "sampleset = sampler.sample(bqm, \n",
     "                           num_reads=num_reads,\n",
     "                           auto_scale=True,\n",
-    "                           num_spin_reversal_transforms=5,\n",
     "                           return_embedding=True,\n",
     "                           answer_mode='raw',\n",
     "                           label='Notebook - Exploring the Pegasus Topology')       "


### PR DESCRIPTION
A [previous PR](https://github.com/dwave-examples/pegasus-notebook/pull/12) met the newly enforced runtime limit by using spin-reversal transforms. This updates the code to meet runtime limits by reducing the number of samples instead. 